### PR TITLE
docs: add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing Guidelines
+
+Thanks for contributing! Please follow these simple rules:
+
+- Keep PRs small and focused.
+- Use branch names like: `feature/<topic>` or `chore/<topic>`.
+- Commit messages should follow: `type: short description`.
+- Link issues in PRs using `Closes #<issue_number>`.
+
+Happy coding! 🚀


### PR DESCRIPTION
Adds CONTRIBUTING.md with basic contributing rules:
- PRs should be small and focused
- Use branch names like feature/<topic> or chore/<topic>
- Commit messages follow "type: short description"
- Link issues in PRs with "Closes #<id>"

Closes #6