### PR TITLE
docs: add glossary of common terms

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -1,0 +1,8 @@
+# Glossary of Common Terms
+
+- **Commit** — A snapshot of changes in the repository.
+- **Branch** — A separate line of development.
+- **Pull Request (PR)** — A proposal to merge changes into the main branch.
+- **Issue** — A way to track tasks, enhancements, or bugs.
+- **README.md** — The main documentation file in a repository.
+- **.gitignore** — File that tells Git which files to ignore.


### PR DESCRIPTION
Adds glossary.md with definitions of common Git and GitHub terms.

Closes #10